### PR TITLE
Fix class unregistration

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -153,7 +153,7 @@ def register():
 
 
 def unregister():
-    for c in classes:
+    for cls in classes:
         bpy.utils.unregister_class(cls)
 
 


### PR DESCRIPTION
A minor typo in the `unregister` function is preventing the class being unregistered correctly.